### PR TITLE
Updated stats tests and simplified likelihood calculation in stats method

### DIFF
--- a/mind_the_gaps/stats.py
+++ b/mind_the_gaps/stats.py
@@ -55,7 +55,7 @@ def chi_cov(powers_data, model_powers=None, inv_cov=None):
     return np.matmul(np.matmul(data_model, inv_cov), data_model.T)
 
 
-def chi_log_likehood(powers_data, model_pows=None, parity=1):
+def chi_log_likehood(powers_data, model_pows=None, nyquist=False):
     """Statistic from Vaughan et al. 2005 Eq. A.3 / Emmanolopoulos+2013 A 11. The last frequency is assumed to be the Nyquist frequency
     and it is also assumed that the 0 frequency power is not given for the calculation of the parity
 
@@ -63,11 +63,14 @@ def chi_log_likehood(powers_data, model_pows=None, parity=1):
         The spectral powers of the data or the realization for the statistic has to be estimated
     model_pows: array_like
         The model
-    parity: int
-        Odd or even number indicating the parity. Assume odd by default
+    nyquist: bool,
+        Indicates whether the Nyquist frequency is included. Default False
     """
-    if parity % 2 == 0:
-        log_like = 2 * np.sum(np.log(model_pows[:-1]) + powers_data[:-1]/ model_pows[:-1]) + np.log(np.pi * powers_data[-1] * model_pows[-1]) + 2 * powers_data[-1] / model_pows[-1]
+
+    if nyquist:
+        log_like = chi_log_likehood_nonyq(powers_data[:-1], model_pows[:-1])
+        # add nyquist contribution
+        log_like += np.log(np.pi * powers_data[-1] * model_pows[-1]) + 2 * powers_data[-1] / model_pows[-1]
     else:
         log_like = chi_log_likehood_nonyq(powers_data, model_pows)
 
@@ -84,7 +87,7 @@ def chi_log_likehood_nonyq(powers_data, model_pows=None):
         The model
     """
 
-    return 2 * np.sum(np.log(model_pows) + powers_data / model_pows)
+    return 2. * np.sum(np.log(model_pows) + powers_data / model_pows)
 
 
 def chi_square(powers_data, model_powers=None, sigmas=None):

--- a/scripts/generate_lcs_goodness.py
+++ b/scripts/generate_lcs_goodness.py
@@ -20,7 +20,16 @@ import random
 
 
 def create_data_selection_figure(outdir, tmax, tmin):
-    """Create figure with the data range used"""
+    """Create figure with the data range used
+
+    Parameters
+    outdir: str,
+        Output dir where to store the figure
+    tmin: float,
+        Minimum time to indicate on the figure (in same units as lightcurve timestamps)
+    tmax: float,
+        Maximum time to indicate on the figure (in same units as lightcurve timestamps)
+    """
 
     data_selection_figure, data_selection_ax = plt.subplots(1, 1)
     plt.xlabel("Time (days)")
@@ -41,7 +50,7 @@ def create_data_selection_figure(outdir, tmax, tmin):
 
 
 def simulate_lcs(sim): # don't pass the PDFs otherwise we the same pdf samples all the time!
-    cmd = "python %s/scripts/pythonscripts/mind_the_gaps/mind_the_gaps/generate_lc.py %s --rootfile _%d_" %  (home, generate_lc_args, sim)
+    cmd = "python %s/scripts/pythonscripts/mind_the_gaps/scripts/generate_lc.py %s --rootfile _%d_" %  (home, generate_lc_args, sim)
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
 
     # Wait for the process to finish and get its output
@@ -85,9 +94,12 @@ pdf = args.pdf
 base_command = "python %s -n %d -f %s --tmin %.2f --tmax %.2f -c %d -s %s -e %.1f --npoints %d --pdf %s -o %s" % (__file__, args.n_sims, args.file,
                 args.tmin, args.tmax, cores, simulator, extension_factor, points_remove, pdf, args.outdir)
 if args.command is not None:
-    python_command = base_command + "--command %s" % args.command
+    python_command = base_command + " --command %s" % args.command
 if args.config is not None:
-    python_command = base_command + "--config %s" % args.config
+    python_command = base_command + " --config %s" % args.config
+if args.noise_std is not None:
+    python_command = base_command + " --noise_std %.3f" % args.noise_std
+
 quantity_support()
 
 home = os.getenv("HOME")

--- a/tests/stats_test.py
+++ b/tests/stats_test.py
@@ -8,29 +8,30 @@ class TestSimulator(unittest.TestCase):
 
     def test_create_lognormal(self):
 
-        var = 5 # desired variance
-        mean = 12 # desired mean
-        samples = create_log_normal(mean, var).rvs(size=2000000)
+        var = 5. # desired variance
+        mean = 12. # desired mean
+        samples = create_log_normal(mean, var).rvs(size=20000000)
         self.assertAlmostEqual(np.mean(samples), mean, 2, "Log normal probability distribution has wrong mean")
         self.assertAlmostEqual(np.var(samples), var, 2, "Log normal probability distribution has wrong variance")
 
 
     def test_create_uniform(self):
 
-        var = 5 # desired variance
-        means = [1, 10, 12] # desired mean
+        var = 5. # desired variance
+        means = [1., 10., 12.] # desired mean
         for mean in means:
-            samples = create_uniform_distribution(mean, var).rvs(size=2000000)
+            samples = create_uniform_distribution(mean, var).rvs(size=20000000)
             self.assertAlmostEqual(np.mean(samples), mean, 2, "Uniform probability distribution has wrong mean")
             self.assertAlmostEqual(np.var(samples), var, 2, "Uniform probability distribution has wrong variance")
 
     def test_lognormal(self):
         log_1 = lognorm(1)
-        samples = log_1.rvs(size=100000)
+        samples = log_1.rvs(size=400000)
         # center 0, sigma = 1
         log_2 = lognormal(a=0)(0, 1)
-        samples_2 = log_2.rvs(size=100000)
-        self.assertAlmostEqual(np.mean(samples), np.mean(samples_2), 3, "Log normal probability distribution gives unexpected results")
+        samples_2 = log_2.rvs(size=50000)
+        self.assertAlmostEqual(np.mean(samples), np.mean(samples_2), delta=0.1, msg="Log normal probability distribution mean fails")
+        self.assertAlmostEqual(np.std(samples), np.std(samples_2), delta=0.1, msg="Log normal probability distribution std fails")
 
     def test_chi_loglikelihood(self):
         data_powers = np.array([0, 1, 2])
@@ -38,23 +39,22 @@ class TestSimulator(unittest.TestCase):
 
         log_like = 2. * (np.log(model_powers[0]) + data_powers[0]/model_powers[0] + np.log(model_powers[1]) + data_powers[1]/model_powers[1] +
                        np.log(model_powers[2]) + data_powers[2]/model_powers[2])
-        self.assertEqual(log_like, chi_log_likehood(data_powers, model_powers), "Log-likehood for odd values gives unexpected results")
+        self.assertAlmostEqual(log_like, chi_log_likehood(data_powers, model_powers, False), msg="Log-likehood gives unexpected results when Nyquist is not included", delta=1E-12)
 
         data_powers = np.array([0, 1, 2, 3])
         model_powers = np.array([0.5, 1.5, 2.5, 3.5])
 
-        log_like = 2 * (np.log(model_powers[0]) + data_powers[0]/model_powers[0] +np.log(model_powers[1]) + data_powers[1]/model_powers[1] +np.log(model_powers[2]) + data_powers[2]/model_powers[2])
+        log_like = 2. * (np.log(model_powers[0]) + data_powers[0]/model_powers[0] +np.log(model_powers[1]) + data_powers[1]/model_powers[1] +np.log(model_powers[2]) + data_powers[2]/model_powers[2])
         log_like += np.log(np.pi * data_powers[-1] * model_powers[-1]) + 2 * data_powers[-1]/model_powers[-1]
-        self.assertEqual(log_like, chi_log_likehood(data_powers, model_powers), "Log-likehood for even values gives unexpected results")
+        self.assertEqual(log_like, chi_log_likehood(data_powers, model_powers, True), "Log-likehood gives unexpected results when Nyquist is included")
 
     def test_chi_cov(self):
-        N = 500
+        N = 10000000
         input_cov = np.array([[1, 1],[1 , 1]])
         samples = np.random.multivariate_normal([0, 0], input_cov, size=N)
         cov = np.cov(samples, rowvar=False, bias=True)
 
-        np.testing.assert_array_almost_equal(input_cov, cov, 4)
-        print(np.linalg.diag(cov))
+        np.testing.assert_array_almost_equal(input_cov, cov, decimal=3)
         model = np.arange(N)
         invcov =  np.linalg.inv(cov)
 
@@ -62,7 +62,7 @@ class TestSimulator(unittest.TestCase):
         model = np.array([5, 2, 6])
         data = np.array([4, 1, 5])
         self.assertAlmostEqual(chi_square(data, model, np.sqrt(np.diag(input_cov))),
-                               chi_cov(data, model, np.linalg.inv(input_cov)), 2)
+                               chi_cov(data, model, np.linalg.inv(input_cov)), 5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed stats_test not passing (issue #13). In most instances either testing accuracy has been reduced or number of samples for the distributions has been increased to increase accuracy. `chi_log_likehood` method on `stats.py` has been simplified and the test updated accordingly.